### PR TITLE
feat(email): add case-share white-label template + values

### DIFF
--- a/base/hub/kerberos-hub-values.yaml
+++ b/base/hub/kerberos-hub-values.yaml
@@ -131,6 +131,8 @@ email:
     forgotTitle: "Password reset Kerberos Hub. You forgot your password"
     share: "share"
     shareTitle: "[Action] You received a recording from Kerberos Hub"
+    caseShare: "share_case"
+    caseShareTitle: "[Action] A case has been shared with you on Kerberos Hub"
     detection: "detection"
     disabled: "disabled"
     highupload: "highupload"

--- a/base/volume/templates/share_case.html
+++ b/base/volume/templates/share_case.html
@@ -1,0 +1,418 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1"
+    />
+    <meta name="description" content="Kerberos.io Mailing">
+    <style type="text/css">
+
+        @font-face {
+            font-family: 'Inter';
+            font-style:  normal;
+            font-weight: 400;
+            font-display: swap;
+            src: url("https://kerberos.io/dist/fonts/Inter-Regular.woff?v=/dist/fonts/Inter-Regular.woff2?v=3.183.18") format("woff2"),
+            url("https://kerberos.io/dist/fonts/Inter-Regular.woff?v=/dist/fonts/Inter-Regular.woff2?v=3.183.18") format("woff");
+        }
+
+        @font-face {
+            font-family: 'Inter';
+            font-style:  normal;
+            font-weight: 500;
+            font-display: swap;
+            src: url("https://kerberos.io/dist/fonts/Inter-Medium.woff2?v=3.18") format("woff2"),
+            url("https://kerberos.io/dist/fonts/Inter-Medium.woff?v=3.18") format("woff");
+        }
+
+        @font-face {
+            font-family: 'Inter';
+            font-style:  normal;
+            font-weight: 600;
+            font-display: swap;
+            src: url("https://kerberos.io/dist/fonts/Inter-SemiBold.woff2?v=3.18") format("woff2"),
+            url("https://kerberos.io/dist/fonts/Inter-SemiBold.woff?v=3.18") format("woff");
+        }
+
+        @font-face {
+            font-family: 'Inter var';
+            font-weight: 100 900;
+            font-display: swap;
+            font-style: normal;
+            font-named-instance: 'Regular';
+            src: url("https://kerberos.io/dist/fonts/Inter-roman.var.woff2?v=3.18") format("woff2");
+        }
+
+        body{
+            background: #E5E5E5;
+            margin-top:0;
+            margin-bottom: 0;
+            margin-right: 0;
+            margin-left: 0;
+            padding-top: 0;
+            padding-left: 0;
+            padding-right: 0;
+            padding-bottom: 0;
+            font-family: 'Inter';
+        }
+        a, a:hover, a:active {
+            color: #262424;
+            text-decoration: none;
+        }
+
+        .corner-td{
+            width: 60px;
+        }
+
+        table {border-collapse:separate;max-width: 850px; margin: 0 auto; width: 100%;}
+        .ExternalClass p, .ExternalClass span, .ExternalClass font, .ExternalClass td {line-height: 100%;}
+        .ExternalClass {width: 100%;}
+        @media screen and (max-width:500px){
+            .tab-td{
+                padding-left: 10px!important;
+            }
+            .tab-td a h4{
+                font-size: 14px!important;
+            }
+            .corner-td{
+                width: 20px!important;
+            }
+            .company-name-td h3{
+                font-size: 16px!important;
+            }
+            table.header-table{
+                padding-top: 8px!important;
+                padding-right: 0px!important;
+                padding-bottom: 24px!important;
+                padding-left: 0px!important;
+            }
+            .colored-card-td  h4{
+                font-size: 14px!important;
+            }
+            .colored-card-td  h2{
+                font-size: 20px!important;
+            }
+            .colored-card-td  a p{
+                font-size: 12px!important;
+                width: 143px!important;
+            }
+            .colored-card-td{
+                padding-top: 24px!important;
+                padding-right: 24px!important;
+                padding-bottom: 24px!important;
+                padding-left: 24px!important;
+            }
+            .colorless-card-td{
+                padding-top: 24px!important;
+                padding-right: 24px!important;
+                padding-bottom: 24px!important;
+                padding-left: 24px!important;
+            }
+            .colorless-card-td h3{
+                font-size: 18px!important;
+            }
+            .colorless-card-td p{
+                font-size: 14px!important;
+            }
+            .colorless-card-table{
+                margin-left: 0px!important;
+                margin-right: 0px!important;
+                margin-top: 24px!important;
+                margin-bottom: 24px!important;
+            }
+            .footer-td{
+                display: table-row!important;
+            }
+        }
+        @media screen and (max-width:600px) {
+            .footer-td{
+                display: table-row!important;
+            }
+        }
+        @media screen and (max-width:650px) {
+            .footer-table{
+                margin-left: 0px!important;
+                margin-right: 0px!important;
+                margin-top: 0px!important;
+                margin-bottom: 36px!important;
+            }
+        }
+    </style>
+</head>
+<body height="100%" width="100%">
+<table border="0" cellpadding="0" cellspacing="0" width="100%" bgcolor="E5E5E5" style="border-collaps:collaps; mso-table-lspace:0pt; mso-table-rspace:0pt;">
+    <tr>
+        <td bgcolor="E5E5E5">
+            <table border="0" cellpadding="0" cellspacing="0" width="100%" height="36" class="header-table" style="padding-top: 36px ;padding-right: 0;padding-bottom: 36px;padding-left: 0;border-collaps:collaps; mso-table-lspace:0pt; mso-table-rspace:0pt;">
+                <tbody>
+                <tr>
+                    <td class="corner-td" align="left"></td>
+                    <td width="48" height="36" align="left"><img alt="Kerberos.io" width="36" height="36"  src="https://kerberos.io/images/email/kerberos.png"/></td>
+                    <td height="36" align="left" class="company-name-td">
+                        <h3  width="36" height="36" style=" font-family: Inter;
+                                        font-size: 20px;
+                                        font-style: normal;
+                                        font-weight: 600;
+                                        line-height: 24px;
+                                        mso-line-height-rule:exactly;
+                                        letter-spacing: 0em;
+                                        text-align: left;
+                                        color: #262424;">Kerberos.io</h3>
+                    </td>
+                    <td  height="36" width="36" style="padding-left: 36px;" class="tab-td" align="right">
+                        <a style="text-decoration: none;color: none;" href={{tab1_href}}>
+                            <h4 style="font-family: Inter;
+                                            font-size: 16px;
+                                            font-style: normal;
+                                            font-weight: 500;
+                                            line-height: 36px;
+                                            mso-line-height-rule:exactly;
+                                            letter-spacing: 0em;
+                                            text-align: right;
+                                            color: #6D6666;">{{tab1_title}}</h4>
+                        </a>
+                    </td>
+                    <td  height="36" width="36" style="padding-left: 36px;" class="tab-td"  align="right" >
+                        <a style="text-decoration: none;color: none;" href={{tab2_href}}>
+                            <h4 style="font-family: Inter;
+                                            font-size: 16px;
+                                            font-style: normal;
+                                            font-weight: 500;
+                                            line-height: 36px;
+                                            mso-line-height-rule:exactly;
+                                            letter-spacing: 0em;
+                                            text-align: right;
+                                            color: #6D6666;">{{tab2_title}}</h4>
+                        </a>
+                    </td>
+                    <td class="corner-td" align="right"></td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+</table>
+<table border="0" cellpadding="0" cellspacing="0" width="100%"  bgcolor="E5E5E5"  style="border-collaps:collaps; mso-table-lspace:0pt; mso-table-rspace:0pt;">
+    <tr>
+        <td bgcolor="E5E5E5">
+            <table border="0" cellpadding="0" cellspacing="0" width="100%" style="border-collaps:collaps; mso-table-lspace:0pt; mso-table-rspace:0pt;" >
+                <tbody>
+                <tr>
+                    <td class="corner-td" align="left"></td>
+                    <td class="colored-card-td" bgcolor="#57356B"  style="padding-left: 48px;padding-right: 48px;padding-top: 48px;padding-bottom: 48px;border-radius: 4px;background-color:#57356B;">
+                        <h2 style=" font-family: Inter;
+                                        font-size: 24px;
+                                        font-style: normal;
+                                        font-weight: 600;
+                                        line-height: 36px;
+                                        mso-line-height-rule:exactly;
+                                        letter-spacing: 0em;
+                                        text-align: left;
+                                        color:#FFFFFF;
+                                        padding-top: 12px;
+                                        margin-bottom: 0;
+                                        padding-bottom: 0;
+                                        padding-left: 0;
+                                        padding-right: 0;">A case has been shared with you</h2>
+                        <h4 style="font-family: Inter;
+                                        font-size: 16px;
+                                        font-style: normal;
+                                        font-weight: 400;
+                                        line-height: 24px;
+                                        mso-line-height-rule:exactly;
+                                        letter-spacing: 0em;
+                                        text-align: left;
+                                        color:#b09fb9;">{{user}} shared a case with you</h4>
+                    </td>
+                    <td class="corner-td" align="right"></td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+</table>
+<table border="0" cellpadding="0" cellspacing="0" width="100%"  bgcolor="E5E5E5"  style="border-collaps:collaps; mso-table-lspace:0pt; mso-table-rspace:0pt;">
+    <tr>
+        <td bgcolor="E5E5E5">
+            <table border="0" cellpadding="0" cellspacing="0" width="100%" class="colorless-card-table" style="margin-top: 36px;margin-bottom: 36px;margin-left: 0;margin-right: 0;border-collaps:collaps; mso-table-lspace:0pt; mso-table-rspace:0pt;"  >
+                <tbody>
+                <tr>
+                    <td class="corner-td" align="left"></td>
+                    <td  class="colorless-card-td" bgcolor="#FFFFFF" style="background-color:#FFFFFF;padding-top: 36px;padding-right: 43px;padding-bottom: 25px;padding-left: 43px;border-radius: 4px;">
+                        <h3 style=" font-family: Inter;
+                                        font-size: 20px;
+                                        font-style: normal;
+                                        font-weight: 600;
+                                        line-height: 36px;
+                                        mso-line-height-rule:exactly;
+                                        letter-spacing: 0em;
+                                        text-align: left;
+                                        color: #262424;
+                                        width: 280px">Open the shared case</h3>
+                        <p style=" font-family: Inter;
+                                        font-size: 14px;
+                                        font-style: normal;
+                                        font-weight: 400;
+                                        line-height: 24px;
+                                        mso-line-height-rule:exactly;
+                                        letter-spacing: 0em;
+                                        text-align: left;
+                                        color: #6D6666;
+                                        margin-top: 12px;">{{user}} has shared a case with you. Click the button below to open it. You'll be asked to request a one-time verification code from the share page itself.<br/><br/>This link will expire in {{expiry}}.</p>
+
+
+						<a style="text-decoration: none;color: none;" href="{{url}}">
+                            <p style="font-family: Inter;
+                                                font-size: 14px;
+                                                font-style: normal;
+                                                line-height: 24px;
+                                                mso-line-height-rule:exactly;
+                                                letter-spacing: 0em;
+                                                text-align: left;
+                                                color:#FFFFFF;
+                                                background-color: #84559F;
+                                                padding-top: 6px;
+                                                padding-bottom: 6px;
+                                                padding-right: 16px;
+                                                padding-left: 16px;
+                                                width: 130px;
+                                                border-radius: 4px;
+												text-align: center;
+                                                cursor: pointer;">Open case -></p>
+                        </a>
+					</td>
+                    <td class="corner-td" align="right"></td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+</table>
+<table border="0" cellpadding="0" cellspacing="0" width="100%"  bgcolor="E5E5E5"  style="border-collaps:collaps; mso-table-lspace:0pt; mso-table-rspace:0pt;">
+    <tr>
+        <td bgcolor="E5E5E5">
+            <table border="0" cellpadding="0" cellspacing="0" width="100%" class="footer-table" style="margin-top: 0;border-collaps:collaps; mso-table-lspace:0pt; mso-table-rspace:0pt;"  >
+                <tbody>
+                <tr>
+                    <td class="corner-td" align="left"></td>
+                    <!--[if mso | IE]>
+                    <table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td style="vertical-align:top;display:table-row !important">
+                    <![endif]-->
+                    <td height="146" width="190" class="footer-td" style="margin-bottom: 12px;"  valign="top" align="left">
+                        <table style="border-collaps:collaps; mso-table-lspace:0pt; mso-table-rspace:0pt;">
+                            <tbody>
+                            <tr>
+                                <td>
+                                    <h4 style=" font-family: Inter;
+                                                        font-size: 16px;
+                                                        font-style: normal;
+                                                        font-weight: 600;
+                                                        line-height: 36px;
+                                                        mso-line-height-rule:exactly;
+                                                        letter-spacing: 0em;
+                                                        text-align: left;
+                                                        color:#6D6666;">Get in touch</h4>
+                                    <a style="text-decoration: none;color: none;" href="mailto:support@kerberos.io">
+                                        <p style=" font-family: Inter;
+                                                            font-size: 14px;
+                                                            font-style: normal;
+                                                            font-weight: 400;
+                                                            line-height: 16px;
+                                                            mso-line-height-rule:exactly;
+                                                            letter-spacing: 0em;
+                                                            text-align: left;
+                                                            color: #A69D9D;">support@kerberos.io</p>
+                                    </a>
+                                    <p style=" font-family: Inter;
+                                                            font-size: 14px;
+                                                            font-style: normal;
+                                                            font-weight: 400;
+                                    line-height: 16px;
+                                    mso-line-height-rule:exactly;
+                                    letter-spacing: 0em;
+                                    text-align: left;
+                                    color: #A69D9D;">9000 Ghent, BE</p>
+
+                                    <a style="text-decoration: none;color: none;" href="https://kerberos.io/">
+                                        <p style=" font-family: Inter;
+                                                            font-size: 14px;
+                                                            font-style: normal;
+                                                            font-weight: 400;
+                                                            line-height: 24px;
+                                                            mso-line-height-rule:exactly;
+                                                            letter-spacing: 0em;
+                                                            text-align: left;
+                                                            color: #A69D9D;">https://kerberos.io</p>
+                                    </a>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                    <!--[if mso | IE]>
+                    <table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td style="vertical-align:top;display:table-row !important">
+                    <![endif]-->
+                    <td class="footer-td" style="border-radius: 4px;padding-left: 0;padding-right: 0;padding-top: 0;padding-bottom: 0; margin-bottom: 12px;"  valign="top" align="left">
+                        <table style="border-collaps:collaps; mso-table-lspace:0pt; mso-table-rspace:0pt;">
+                            <tbody>
+                            <tr>
+                                <td>
+                                    <h4 style=" font-family: Inter;
+                                                        font-size: 16px;
+                                                        font-style: normal;
+                                                        font-weight: 600;
+                                                        line-height: 36px;
+                                                        mso-line-height-rule:exactly;
+                                                        letter-spacing: 0em;
+                                                        text-align: left;
+                                                        color:#6D6666;">About Kerberos</h4>
+                                    <p style=" font-family: Inter;
+                                                        font-size: 14px;
+                                                        font-style: normal;
+                                                        font-weight: 400;
+                                                        line-height: 24px;
+                                                        mso-line-height-rule:exactly;
+                                                        letter-spacing: 0em;
+                                                        text-align: left;
+                                                        color: #A69D9D;">Welcome to the revolutionary video analytics and video management platform. Open, modular, and extensible for everyone, anywhere.</p>
+                                                        
+                                    
+                                    <p style="margin-top: 12px;">
+                                        <a href="https://twitter.com/kerberosio" style="text-decoration: none;color: none;">
+                                            <img width="24" height="24" alt="Twitter" src="https://kerberos.io/images/email/twitter.png"/>
+                                        </a>
+                                        <a href="https://reddit.com/r/kerberos_io" style="text-decoration: none;color: none;">
+                                            <img g width="24" height="24" alt="Reddit" src="https://kerberos.io/images/email/reddit.png"/>
+                                        </a>
+                                        <a href="https://www.youtube.com/channel/UCnd9q7iRNNw4W95eQwQuECA" style="text-decoration: none;color: none;">
+                                            <img g width="24" height="24" alt="Youtube" src="https://kerberos.io/images/email/youtube.png"/>
+                                        </a>
+                                        <a href="https://github.com/kerberos-io" style="text-decoration: none;color: none;">
+                                            <img g width="24" height="24" alt="Github" src="https://kerberos.io/images/email/github.png"/>
+                                        </a>
+                                    </p>                
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                    <td class="corner-td" align="right"></td>
+                </tr>
+                </tbody>
+            </table>
+            <table style="border-collaps:collaps; mso-table-lspace:0pt; mso-table-rspace:0pt;">
+                <tbody>
+                    <tr style="height: 50px">
+                        <td></td>
+                    </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+</table>
+</body>
+</html>

--- a/base/volume/templates/share_case.txt
+++ b/base/volume/templates/share_case.txt
@@ -1,0 +1,21 @@
+Kerberos.io
+------------
+
+A case has been shared with you
+{{user}} shared a case with you
+
+Open the shared case
+{{user}} has shared a case with you. Open the link below to access it — you'll be asked to request a one-time verification code from the share page.
+{{url}}
+
+This link will expire in {{expiry}}.
+
+Get in touch
+------------
+support@kerberos.io
+9000 Ghent, BE
+https://kerberos.io
+
+About Kerberos
+------------
+Welcome to the revolutionary video analytics and video management platform. Open, modular, and extensible for everyone, anywhere.


### PR DESCRIPTION
## What

Adds the dedicated **case-share** email template and wires it into the hub email values so case-share invitations render with their own template instead of reusing the recording-share one.

- `base/volume/templates/share_case.html` + `share_case.txt` — Kerberos-branded white-label template (placeholders: `{{user}}`, `{{firstname}}`, `{{lastname}}`, `{{url}}`, `{{expiry}}`).
- `base/hub/kerberos-hub-values.yaml` — adds `email.templates.caseShare` (`share_case`) and `caseShareTitle`.

## Why

hub-api now calls `SendCaseShareEmail`, which selects the template/title via `CASE_SHARE_TEMPLATE`/`CASE_SHARE_TITLE`. This provides the white-label override for branded deployments. Default deployments already render the brand-neutral `share_case` template baked into `hub-pipeline-notification` v1.3.12.

## Related
- hub-pipeline-notification#100 (template) — released in v1.3.12
- hub-api#430 (SendCaseShareEmail) — merged
- helm-charts: companion PR adds the same wiring for Helm deployments.